### PR TITLE
Remove print and allow for grad directly on the predict method

### DIFF
--- a/cosmopower_jax/cosmopower_jax.py
+++ b/cosmopower_jax/cosmopower_jax.py
@@ -119,14 +119,14 @@ class CosmoPowerJAX:
             except:
                 # in this case, we fall back to the dictionary that is created
                 # when running the convert_tf214.py script, available in the root folder
-                print('Tried to load pickle file from pre-trained model, but failed.')
-                print('This usually means that you have TF>=2.14, or that you are loading a model' \
-                      ' that was trained on PCA but loaded with the log (or viceversa), or that' \
-                      ' you are loading a non-standard model from the cosmopower-organization repo.')
-                print('Falling back to the dictionary, if case this also fails or does not output the right shape' \
-                      ' make sure you ran the `convert_tf214.py` script, and that a `.npz` file exists among' \
-                      ' the trained models, and that you ran `pip install .`. Also make sure' \
-                      ' that you are asking for the right probe between `custom_log` and `custom_pca`.')
+                # print('Tried to load pickle file from pre-trained model, but failed.')
+                # print('This usually means that you have TF>=2.14, or that you are loading a model' \
+                #       ' that was trained on PCA but loaded with the log (or viceversa), or that' \
+                #       ' you are loading a non-standard model from the cosmopower-organization repo.')
+                # print('Falling back to the dictionary, if case this also fails or does not output the right shape' \
+                #       ' make sure you ran the `convert_tf214.py` script, and that a `.npz` file exists among' \
+                #       ' the trained models, and that you ran `pip install .`. Also make sure' \
+                #       ' that you are asking for the right probe between `custom_log` and `custom_pca`.')
                 # the [:-4] should ensure we remove the .pkl suffix,
                 # ensuring backward compatibility
                 if filename is not None:

--- a/cosmopower_jax/cosmopower_jax.py
+++ b/cosmopower_jax/cosmopower_jax.py
@@ -228,14 +228,14 @@ class CosmoPowerJAX:
                 except:
                     # in this case, we fall back to the dictionary that is created
                     # when running the convert_tf214.py script, available in the root folder
-                    print('Tried to load pickle file from pre-trained model, but failed.')
-                    print('This usually means that you have TF>=2.14, or that you are loading a model' \
-                          ' that was trained on PCA but loaded with the log (or viceversa), or that' \
-                          ' you are loading a non-standard model from the cosmopower-organization repo.')
-                    print('Falling back to the dictionary, if case this also fails or does not output the right shape' \
-                          ' make sure you ran the `convert_tf214.py` script, and that a `.npz` file exists among' \
-                          ' the trained models, and that you ran `pip install .`. Also make sure' \
-                          ' that you are asking for the right probe between `custom_log` and `custom_pca`.')
+                    # print('Tried to load pickle file from pre-trained model, but failed.')
+                    # print('This usually means that you have TF>=2.14, or that you are loading a model' \
+                    #       ' that was trained on PCA but loaded with the log (or viceversa), or that' \
+                    #       ' you are loading a non-standard model from the cosmopower-organization repo.')
+                    # print('Falling back to the dictionary, if case this also fails or does not output the right shape' \
+                    #       ' make sure you ran the `convert_tf214.py` script, and that a `.npz` file exists among' \
+                    #       ' the trained models, and that you ran `pip install .`. Also make sure' \
+                    #       ' that you are asking for the right probe between `custom_log` and `custom_pca`.')
                     # the [:-4] should ensure we remove the .pkl suffix, 
                     # ensuring backward compatibility
                     if filename is not None:
@@ -310,14 +310,14 @@ class CosmoPowerJAX:
                     except:
                         # in this case, we fall back to the dictionary that is created
                         # when running the convert_tf214.py script, available in the root folder
-                        print('Tried to load pickle file from pre-trained model, but failed.')
-                        print('This usually means that you have TF>=2.14, or that you are loading a model' \
-                              ' that was trained on PCA but loaded with the log (or viceversa), or that' \
-                              ' you are loading a non-standard model from the cosmopower-organization repo.')
-                        print('Falling back to the dictionary, if case this also fails or does not output the right shape' \
-                              ' make sure you ran the `convert_tf214.py` script, and that a `.npz` file exists among' \
-                              ' the trained models, and that you ran `pip install .`. Also make sure' \
-                              ' that you are asking for the right probe between `custom_log` and `custom_pca`.')
+                        # print('Tried to load pickle file from pre-trained model, but failed.')
+                        # print('This usually means that you have TF>=2.14, or that you are loading a model' \
+                        #       ' that was trained on PCA but loaded with the log (or viceversa), or that' \
+                        #       ' you are loading a non-standard model from the cosmopower-organization repo.')
+                        # print('Falling back to the dictionary, if case this also fails or does not output the right shape' \
+                        #       ' make sure you ran the `convert_tf214.py` script, and that a `.npz` file exists among' \
+                        #       ' the trained models, and that you ran `pip install .`. Also make sure' \
+                        #       ' that you are asking for the right probe between `custom_log` and `custom_pca`.')
                         # the [:-4] should ensure we remove the .pkl suffix,
                         # ensuring backward compatibility
                         loaded_variable_dict = np.load(f'{filepath[:-4]}.npz', allow_pickle=True)

--- a/cosmopower_jax/cosmopower_jax.py
+++ b/cosmopower_jax/cosmopower_jax.py
@@ -3,6 +3,7 @@ import numpy as np
 import jax.numpy as jnp
 from jax.nn import sigmoid
 from jax import jacfwd, jacrev
+from jax.errors import TracerArrayConversionError
 
 # to deal with the pre-saved models and PCA attributes
 try:
@@ -381,7 +382,12 @@ class CosmoPowerJAX:
                 parameters sorted according to desired order
         """
         if self.parameters is not None:
-            return np.stack([input_dict[k] for k in self.parameters], axis=1)
+            try:
+                return np.stack([input_dict[k] for k in self.parameters], axis=1)
+            except TracerArrayConversionError:
+                converted_dict = {k: jnp.array(v) if isinstance(v, list) else v for k, v in input_dict.items()}
+                return jnp.stack([converted_dict[k] for k in self.parameters], axis=1)
+
         else:
             return np.stack([input_dict[k] for k in input_dict], axis=1)
 


### PR DESCRIPTION
Remove long print here: 
```
Tried to load pickle file from pre-trained model, but failed
...
```

(maybe make them optional?)

Exception handling to take gradients directly on predict method:

```
            try:
                return np.stack([input_dict[k] for k in self.parameters], axis=1)
            except TracerArrayConversionError:
                converted_dict = {k: jnp.array(v) if isinstance(v, list) else v for k, v in input_dict.items()}
                return jnp.stack([converted_dict[k] for k in self.parameters], axis=1)
```