### PR TITLE
Replace np.stack() with jnp.stack() inside _dict_to_ordered_arr_np()

### DIFF
--- a/cosmopower_jax/cosmopower_jax.py
+++ b/cosmopower_jax/cosmopower_jax.py
@@ -386,9 +386,9 @@ class CosmoPowerJAX:
                 parameters sorted according to desired order
         """
         if self.parameters is not None:
-            return np.stack([input_dict[k] for k in self.parameters], axis=1)
+            return jnp.stack([input_dict[k] for k in self.parameters], axis=1)
         else:
-            return np.stack([input_dict[k] for k in input_dict], axis=1)
+            return jnp.stack([input_dict[k] for k in input_dict], axis=1)
 
     def _activation(self, x, a, b):
         """Non-linear activation function. Based on the original CosmoPower paper, Eq. A1.


### PR DESCRIPTION
Clone PR of my earlier PR[#16](https://github.com/dpiras/cosmopower-jax/pull/16#issue-3128120516) with the clean git history. Actually, upon a closer look at the previous PRs, I think this is similar if not the same to the use case mentioned by @borisbolliet in PR[#12](https://github.com/dpiras/cosmopower-jax/pull/12#issue-2630533596). Happy to iterate!

When I use `CosmoPowerJax` instances inside another function and, say, I want to get the Jacobian of the wrapper function using, e.g., `jax.jacfwd`, I get an error from the np.stack() inside the current _dict_to_ordered_arr_np() helper.

I could solve the problem by simply replacing np.stack() with the jax.numpy replacement. So I wonder if there is a good reason to use np.stack() instead of jnp.stack() there?

Below is a minimal example.

```
import jax
# Enable double precision
jax.config.update("jax_enable_x64", True)
import numpy as np
from cosmopower_jax.cosmopower_jax import CosmoPowerJAX

def get_pgg(cosmo_dict, bias_dict, pshot, k, pklin_emulator=CosmoPowerJAX(probe='mpk_lin')):
    #klin = pklin_emulator.modes / cosmo_dict['h']
    pklin = pklin_emulator.predict(cosmo_dict)
    pgg=(bias_dict['b1']**2)*pklin+pshot
    return pgg

pklin_emulator=CosmoPowerJAX(probe='mpk_lin')
print(pklin_emulator.parameters)
cosmo_dict = {'omega_b': np.array([0.02242]), 'omega_cdm': np.array([0.11933]),\
                    'ln10^{10}A_s': np.array([3.047]), 'n_s': np.array([0.9665]),\
                    'h': np.array([0.6766]),\
                    'z': np.array([0.0])}

k = np.linspace(1e-4,0.4,200)
bias_dict = {'b1': np.array([1.2]),}
pshot=0.
jac = jax.jacfwd(get_pgg,argnums=[0,1,])(cosmo_dict, bias_dict, pshot, k, pklin_emulator=pklin_emulator)
```