### PR TITLE
Add the new custom probe to old CP model cases

### DIFF
--- a/cosmopower_jax/cosmopower_jax.py
+++ b/cosmopower_jax/cosmopower_jax.py
@@ -439,7 +439,7 @@ class CosmoPowerJAX:
 
         # Final layer prediction (no activations)
         w, b = weights[-1]
-        if self.probe == 'custom_log' or self.probe == 'custom_pca':
+        if self.probe in ['custom_log','custom_pca','custom']:
             # in original CP models, we assumed a full final bias vector...
             preds = jnp.dot(layer_out[-1], w.T) + b
         else:   


### PR DESCRIPTION
Hi @dpiras ! Apologies for my oversight but I left `custom` out of the cases of old CP models (`custom_log` and `custom_pca`) when computing precitions from weights and biases. That introduces a small but non-negligible error to the output of `predcit()`. Should be corrected by this commit. Sorry again!